### PR TITLE
feat: retrieve also current version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
+const analyzeCommits = require('./lib/analyzeCommits')
 const prepare = require('./lib/prepare')
 
 module.exports = {
-  prepare
+	analyzeCommits,
+	prepare
 }

--- a/lib/analyzeCommits.js
+++ b/lib/analyzeCommits.js
@@ -1,0 +1,6 @@
+module.exports = async (pluginConfig, { lastRelease: { version }, logger }) => {
+	const varName = pluginConfig.varName || 'nextRelease'
+	logger.log(`Setting current version ${version} to the env var ${varName}`)
+
+	console.log(`##vso[task.setvariable variable=${varName}]${version}`)
+}


### PR DESCRIPTION
If there are no relevant changes, the nextRelease variable gets not set. In this case the current version is interesting. Therefore it gets set now in the analyzeCommits step.