### PR TITLE
build: bump peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "eslint-plugin-standard": "^4.0.0"
   },
   "peerDependencies": {
-    "semantic-release": ">=11.0.0 <16.0.0"
+    "semantic-release": ">=11.0.0 <18.0.0"
   }
 }


### PR DESCRIPTION
* Update semantic-release upper boundary to 18.X

Closes #6 