### PR TITLE
fix: 🐛 Fixes dependancy of semantic-release to 18.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "eslint-plugin-standard": "^4.0.0"
   },
   "peerDependencies": {
-    "semantic-release": ">=11.0.0 <18.0.9"
+    "semantic-release": ">=11.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "eslint-plugin-standard": "^4.0.0"
   },
   "peerDependencies": {
-    "semantic-release": ">=11.0.0 <18.0.0"
+    "semantic-release": ">=11.0.0 <18.0.9"
   }
 }


### PR DESCRIPTION
✅ Closes: #17