### PR TITLE
feat: adding the ability to set the `isOutput` to true from within plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The behavior when no new release is available can be configured with *setOnlyOnR
 |------------------|-------------------------------------------------------|
 | varName          | Name of the variable that will store the next version. Defaults to *nextRelease*. |
 | setOnlyOnRelease | `Bool`. Determines if the variable with the new version will be set only when a new version is available. <br> If set to `false`, the next version variable will store the last released version when no new version is available.<br> Defaults to *true*. |
+| isOutput | `Bool`. Determines whether or not you want to set your version to be set as output for the step<br> If set to `true`, the version will be set as output and will be available in susequent stages that depend on it.<br> Defaults to *false*. |
 
 
 The following examples store the generated version number in a variable named *version*.
@@ -57,6 +58,7 @@ plugins:
   - - "semantic-release-ado"
     - varName: "version"
       setOnlyOnRelease: true
+      isOutput: true #defaults to false
 ```
 
 `JSON`:
@@ -65,7 +67,8 @@ plugins:
   "plugins": [
     ["semantic-release-ado", {
       "varName": "version",
-      "setOnlyOnRelease": true
+      "setOnlyOnRelease": true,
+      "isOutput": true //defaults to false
     }],
   ]
 }

--- a/lib/analyzeCommits.js
+++ b/lib/analyzeCommits.js
@@ -3,7 +3,7 @@ module.exports = async (pluginConfig, { lastRelease: { version }, logger }) => {
 
   if (!setOnlyOnRelease) {
     const varName = pluginConfig.varName || 'nextRelease'
-    const isOutput = pluginConfig.isOutputVar || false
+    const isOutput = pluginConfig.isOutput|| false
     logger.log(`Setting current version ${version} to the env var ${varName}`)
 
     console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${version}`)

--- a/lib/analyzeCommits.js
+++ b/lib/analyzeCommits.js
@@ -3,8 +3,9 @@ module.exports = async (pluginConfig, { lastRelease: { version }, logger }) => {
 
   if (!setOnlyOnRelease) {
     const varName = pluginConfig.varName || 'nextRelease'
+    const isOutput = pluginConfig.isOutputVar || false
     logger.log(`Setting current version ${version} to the env var ${varName}`)
 
-    console.log(`##vso[task.setvariable variable=${varName}]${version}`)
+    console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${version}`)
   }
 }

--- a/lib/verifyRelease.js
+++ b/lib/verifyRelease.js
@@ -1,8 +1,8 @@
 module.exports = async (pluginConfig, { nextRelease: { version }, logger }) => {
   const varName = pluginConfig.varName || 'nextRelease'
-  const isOutput = pluginConfig.isOutputVar || false
+  const isOutput = pluginConfig.isOutput || false
 
   logger.log(`Setting version ${version} to the env var ${varName}`)
-  
+
   console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${version}`)
 }

--- a/lib/verifyRelease.js
+++ b/lib/verifyRelease.js
@@ -1,6 +1,8 @@
 module.exports = async (pluginConfig, { nextRelease: { version }, logger }) => {
   const varName = pluginConfig.varName || 'nextRelease'
-  logger.log(`Setting version ${version} to the env var ${varName}`)
+  const isOutput = pluginConfig.isOutputVar || false
 
-  console.log(`##vso[task.setvariable variable=${varName}]${version}`)
+  logger.log(`Setting version ${version} to the env var ${varName}`)
+  
+  console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${version}`)
 }


### PR DESCRIPTION
# Overview
Looking to get the ability to use the `isOutput` flag for later using in other stages that depend on the version

@lluchmk 
Let me know if you want me to update the section in the readme to include an example of using the value in other stages