### PR TITLE
Add ado variables for all aspects of the  release object for lastRelease and nextRelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Semantic release plugin for automatic builds on Azure DevOps pipelines.
 
 | Step             | Description |
 |------------------|-------------|
-| `analyzeCommits` | If configured to do so, stores the current version as an Azure DevOps pipeline variable. |
-| `verifyRelease`  | Stores the next version as an Azure DevOps pipeline variable availabe to downstream steps on the job. |
+| `analyzeCommits` | If configured to do so, stores the current version as an Azure DevOps pipeline variable. Optionally exposes properties from the last release as individual variables. |
+| `verifyRelease`  | Stores the next version as an Azure DevOps pipeline variable availabe to downstream steps on the job. Optionally exposes individual properties from the next release as separate variables. |
 
 ## Install
 
@@ -43,14 +43,43 @@ The behavior when no new release is available can be configured with *setOnlyOnR
 
 ### Options
 
+#### Core Options
+
 | **Options**      | **Desctiption**                                       |
 |------------------|-------------------------------------------------------|
 | varName          | Name of the variable that will store the next version. Defaults to *nextRelease*. |
 | setOnlyOnRelease | `Bool`. Determines if the variable with the new version will be set only when a new version is available. <br> If set to `false`, the next version variable will store the last released version when no new version is available.<br> Defaults to *true*. |
 | isOutput         | `Bool`. Determines whether the version will be set as an output variable, so it is available in later stages.<br> Defaults to *false*. |
 
+#### Release Object Variables (Next Release)
+These options enable exposing individual properties from the next release as separate variables in the `verifyRelease` hook.
 
-The following examples store the generated version number in a variable named *version*.
+| **Options**              | **Description**                                       |
+|--------------------------|-------------------------------------------------------|
+| setReleaseObjectVariables | `Bool`. Enables individual next release property variables. Defaults to *false*. |
+| releaseVersionVarName     | Name of the variable that will store the next release version. Defaults to *releaseVersion*. |
+| releaseTypeVarName        | Name of the variable that will store the semver type (major, minor, patch). Defaults to *releaseType*. |
+| releaseGitHeadVarName     | Name of the variable that will store the git commit SHA. Defaults to *releaseGitHead*. |
+| releaseGitTagVarName      | Name of the variable that will store the git tag. Defaults to *releaseGitTag*. |
+| releaseNotesVarName       | Name of the variable that will store the release notes. Defaults to *releaseNotes*. |
+| releaseChannelVarName     | Name of the variable that will store the distribution channel. Defaults to *releaseChannel*. |
+
+#### Last Release Object Variables
+These options enable exposing individual properties from the last release as separate variables in the `analyzeCommits` hook.
+
+| **Options**               | **Description**                                       |
+|---------------------------|-------------------------------------------------------|
+| setLastReleaseObjectVariables | `Bool`. Enables individual last release property variables. Defaults to *false*. |
+| lastReleaseVersionVarName     | Name of the variable that will store the last release version. Defaults to *lastReleaseVersion*. |
+| lastReleaseGitHeadVarName     | Name of the variable that will store the last release git commit SHA. Defaults to *lastReleaseGitHead*. |
+| lastReleaseGitTagVarName      | Name of the variable that will store the last release git tag. Defaults to *lastReleaseGitTag*. |
+| lastReleaseChannelVarName     | Name of the variable that will store the last release distribution channel. Defaults to *lastReleaseChannel*. |
+
+### Examples
+
+#### Basic Configuration
+
+The following example stores the generated version number in a variable named *version*.
 
 `YAML`:
 ```yaml
@@ -68,11 +97,44 @@ plugins:
     ["semantic-release-ado", {
       "varName": "version",
       "setOnlyOnRelease": true,
-      "isOutput": true //defaults to false
-    }],
+      "isOutput": true
+    }]
   ]
 }
 ```
+
+#### Using Release Object Variables
+
+The following example enables individual release properties as separate variables.
+
+`YAML`:
+```yaml
+plugins:
+  - - "semantic-release-ado"
+    - varName: "nextRelease"
+      setReleaseObjectVariables: true
+      setLastReleaseObjectVariables: true
+      isOutput: true
+```
+
+`JSON`:
+```json
+{
+  "plugins": [
+    ["semantic-release-ado", {
+      "varName": "nextRelease",
+      "setReleaseObjectVariables": true,
+      "setLastReleaseObjectVariables": true,
+      "isOutput": true
+    }]
+  ]
+}
+```
+
+This will set the following variables when a release is published:
+
+- From `verifyRelease`: `releaseVersion`, `releaseType`, `releaseGitHead`, `releaseGitTag`, `releaseNotes`, `releaseChannel`
+- From `analyzeCommits`: `lastReleaseVersion`, `lastReleaseGitHead`, `lastReleaseGitTag`, `lastReleaseChannel`
 
 ## Azure DevOps build pipeline YAML example:
 

--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ plugins:
     ["semantic-release-ado", {
       "varName": "nextRelease",
       "setWouldRelease": true,
-      "isOutput": true
-    }]
+      "isOutput": true //defaults to false
+    }],
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ The behavior when no new release is available can be configured with *setOnlyOnR
 | varName          | Name of the variable that will store the next version. Defaults to *nextRelease*. |
 | setOnlyOnRelease | `Bool`. Determines if the variable with the new version will be set only when a new version is available. <br> If set to `false`, the next version variable will store the last released version when no new version is available.<br> Defaults to *true*. |
 | isOutput         | `Bool`. Determines whether the version will be set as an output variable, so it is available in later stages.<br> Defaults to *false*. |
+| setWouldRelease  | `Bool`. Enables a boolean variable indicating whether a release will be published. Defaults to *false*. |
+| wouldReleaseVarName | Name of the variable that will store the would_release flag. Defaults to *would_release*. |
 
 #### Release Object Variables (Next Release)
 These options enable exposing individual properties from the next release as separate variables in the `verifyRelease` hook.
@@ -102,6 +104,34 @@ plugins:
   ]
 }
 ```
+
+#### Using Would Release Variable
+
+The following example enables the `would_release` boolean variable to indicate whether a release will be published.
+
+`YAML`:
+```yaml
+plugins:
+  - - "semantic-release-ado"
+    - varName: "nextRelease"
+      setWouldRelease: true
+      isOutput: true
+```
+
+`JSON`:
+```json
+{
+  "plugins": [
+    ["semantic-release-ado", {
+      "varName": "nextRelease",
+      "setWouldRelease": true,
+      "isOutput": true
+    }]
+  ]
+}
+```
+
+This will set a `would_release` variable to `false` during the `analyzeCommits` stage and `true` during the `verifyRelease` stage if a new release will be published. You can use this variable in downstream steps to conditionally execute tasks only when a release is being made.
 
 #### Using Release Object Variables
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ These options enable exposing individual properties from the next release as sep
 | releaseTypeVarName        | Name of the variable that will store the semver type (major, minor, patch). Defaults to *releaseType*. |
 | releaseGitHeadVarName     | Name of the variable that will store the git commit SHA. Defaults to *releaseGitHead*. |
 | releaseGitTagVarName      | Name of the variable that will store the git tag. Defaults to *releaseGitTag*. |
-| releaseNotesVarName       | Name of the variable that will store the release notes. Defaults to *releaseNotes*. |
 | releaseChannelVarName     | Name of the variable that will store the distribution channel. Defaults to *releaseChannel*. |
 
 #### Last Release Object Variables
@@ -163,7 +162,7 @@ plugins:
 
 This will set the following variables when a release is published:
 
-- From `verifyRelease`: `releaseVersion`, `releaseType`, `releaseGitHead`, `releaseGitTag`, `releaseNotes`, `releaseChannel`
+- From `verifyRelease`: `releaseVersion`, `releaseType`, `releaseGitHead`, `releaseGitTag`, `releaseChannel`
 - From `analyzeCommits`: `lastReleaseVersion`, `lastReleaseGitHead`, `lastReleaseGitTag`, `lastReleaseChannel`
 
 ## Azure DevOps build pipeline YAML example:
@@ -191,7 +190,7 @@ jobs:
 ### Configuration:
 Below is the configuration for setting `isOutput` to true, which will allow the variable to be referenced from other jobs/stages
 
-`JSON`: 
+`JSON`:
 ```json
 {
   "plugins": [
@@ -236,7 +235,7 @@ jobs:
 ### In another stage:
 
 ```yaml
-stages: 
+stages:
   - stage: Stage1
     jobs:
     - job: Job1

--- a/lib/analyzeCommits.js
+++ b/lib/analyzeCommits.js
@@ -1,11 +1,39 @@
-module.exports = async (pluginConfig, { lastRelease: { version }, logger }) => {
+module.exports = async (pluginConfig, { lastRelease, logger }) => {
   const setOnlyOnRelease = pluginConfig.setOnlyOnRelease === undefined ? true : !!pluginConfig.setOnlyOnRelease
+  const isOutput = pluginConfig.isOutput || false
+  const setLastReleaseObjectVariables = pluginConfig.setLastReleaseObjectVariables || false
 
-  if (!setOnlyOnRelease) {
+  if (!setOnlyOnRelease && lastRelease && lastRelease.version) {
     const varName = pluginConfig.varName || 'nextRelease'
-    const isOutput = pluginConfig.isOutput|| false
-    logger.log(`Setting current version ${version} to the env var ${varName}`)
+    logger.log(`Setting current version ${lastRelease.version} to the env var ${varName}`)
 
-    console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${version}`)
+    console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${lastRelease.version}`)
+  }
+
+  if (setLastReleaseObjectVariables && lastRelease) {
+    const lastReleaseVersionVarName = pluginConfig.lastReleaseVersionVarName || 'lastReleaseVersion'
+    const lastReleaseGitHeadVarName = pluginConfig.lastReleaseGitHeadVarName || 'lastReleaseGitHead'
+    const lastReleaseGitTagVarName = pluginConfig.lastReleaseGitTagVarName || 'lastReleaseGitTag'
+    const lastReleaseChannelVarName = pluginConfig.lastReleaseChannelVarName || 'lastReleaseChannel'
+
+    if (lastRelease.version) {
+      logger.log(`Setting last release version ${lastRelease.version} to the env var ${lastReleaseVersionVarName}`)
+      console.log(`##vso[task.setvariable variable=${lastReleaseVersionVarName};isOutput=${isOutput}]${lastRelease.version}`)
+    }
+
+    if (lastRelease.gitHead) {
+      logger.log(`Setting last release gitHead ${lastRelease.gitHead} to the env var ${lastReleaseGitHeadVarName}`)
+      console.log(`##vso[task.setvariable variable=${lastReleaseGitHeadVarName};isOutput=${isOutput}]${lastRelease.gitHead}`)
+    }
+
+    if (lastRelease.gitTag) {
+      logger.log(`Setting last release gitTag ${lastRelease.gitTag} to the env var ${lastReleaseGitTagVarName}`)
+      console.log(`##vso[task.setvariable variable=${lastReleaseGitTagVarName};isOutput=${isOutput}]${lastRelease.gitTag}`)
+    }
+
+    if (lastRelease.channel) {
+      logger.log(`Setting last release channel ${lastRelease.channel} to the env var ${lastReleaseChannelVarName}`)
+      console.log(`##vso[task.setvariable variable=${lastReleaseChannelVarName};isOutput=${isOutput}]${lastRelease.channel}`)
+    }
   }
 }

--- a/lib/analyzeCommits.js
+++ b/lib/analyzeCommits.js
@@ -2,12 +2,19 @@ module.exports = async (pluginConfig, { lastRelease, logger }) => {
   const setOnlyOnRelease = pluginConfig.setOnlyOnRelease === undefined ? true : !!pluginConfig.setOnlyOnRelease
   const isOutput = pluginConfig.isOutput || false
   const setLastReleaseObjectVariables = pluginConfig.setLastReleaseObjectVariables || false
+  const setWouldRelease = pluginConfig.setWouldRelease || false
 
   if (!setOnlyOnRelease && lastRelease && lastRelease.version) {
     const varName = pluginConfig.varName || 'nextRelease'
     logger.log(`Setting current version ${lastRelease.version} to the env var ${varName}`)
 
     console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${lastRelease.version}`)
+  }
+
+  if (setWouldRelease) {
+    const wouldReleaseVarName = pluginConfig.wouldReleaseVarName || 'would_release'
+    logger.log(`Setting would_release to false (no release determined yet)`)
+    console.log(`##vso[task.setvariable variable=${wouldReleaseVarName};isOutput=${isOutput}]false`)
   }
 
   if (setLastReleaseObjectVariables && lastRelease) {

--- a/lib/verifyRelease.js
+++ b/lib/verifyRelease.js
@@ -19,7 +19,6 @@ module.exports = async (pluginConfig, { nextRelease, logger }) => {
     const releaseTypeVarName = pluginConfig.releaseTypeVarName || 'releaseType'
     const releaseGitHeadVarName = pluginConfig.releaseGitHeadVarName || 'releaseGitHead'
     const releaseGitTagVarName = pluginConfig.releaseGitTagVarName || 'releaseGitTag'
-    const releaseNotesVarName = pluginConfig.releaseNotesVarName || 'releaseNotes'
     const releaseChannelVarName = pluginConfig.releaseChannelVarName || 'releaseChannel'
 
     if (nextRelease.version) {
@@ -40,11 +39,6 @@ module.exports = async (pluginConfig, { nextRelease, logger }) => {
     if (nextRelease.gitTag) {
       logger.log(`Setting release gitTag ${nextRelease.gitTag} to the env var ${releaseGitTagVarName}`)
       console.log(`##vso[task.setvariable variable=${releaseGitTagVarName};isOutput=${isOutput}]${nextRelease.gitTag}`)
-    }
-
-    if (nextRelease.notes) {
-      logger.log(`Setting release notes to the env var ${releaseNotesVarName}`)
-      console.log(`##vso[task.setvariable variable=${releaseNotesVarName};isOutput=${isOutput}]${nextRelease.notes}`)
     }
 
     if (nextRelease.channel) {

--- a/lib/verifyRelease.js
+++ b/lib/verifyRelease.js
@@ -2,10 +2,17 @@ module.exports = async (pluginConfig, { nextRelease, logger }) => {
   const varName = pluginConfig.varName || 'nextRelease'
   const isOutput = pluginConfig.isOutput || false
   const setReleaseObjectVariables = pluginConfig.setReleaseObjectVariables || false
+  const setWouldRelease = pluginConfig.setWouldRelease || false
 
   logger.log(`Setting version ${nextRelease.version} to the env var ${varName}`)
 
   console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${nextRelease.version}`)
+
+  if (setWouldRelease) {
+    const wouldReleaseVarName = pluginConfig.wouldReleaseVarName || 'would_release'
+    logger.log(`Setting would_release to true`)
+    console.log(`##vso[task.setvariable variable=${wouldReleaseVarName};isOutput=${isOutput}]true`)
+  }
 
   if (setReleaseObjectVariables) {
     const releaseVersionVarName = pluginConfig.releaseVersionVarName || 'releaseVersion'

--- a/lib/verifyRelease.js
+++ b/lib/verifyRelease.js
@@ -1,8 +1,48 @@
-module.exports = async (pluginConfig, { nextRelease: { version }, logger }) => {
+module.exports = async (pluginConfig, { nextRelease, logger }) => {
   const varName = pluginConfig.varName || 'nextRelease'
   const isOutput = pluginConfig.isOutput || false
+  const setReleaseObjectVariables = pluginConfig.setReleaseObjectVariables || false
 
-  logger.log(`Setting version ${version} to the env var ${varName}`)
+  logger.log(`Setting version ${nextRelease.version} to the env var ${varName}`)
 
-  console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${version}`)
+  console.log(`##vso[task.setvariable variable=${varName};isOutput=${isOutput}]${nextRelease.version}`)
+
+  if (setReleaseObjectVariables) {
+    const releaseVersionVarName = pluginConfig.releaseVersionVarName || 'releaseVersion'
+    const releaseTypeVarName = pluginConfig.releaseTypeVarName || 'releaseType'
+    const releaseGitHeadVarName = pluginConfig.releaseGitHeadVarName || 'releaseGitHead'
+    const releaseGitTagVarName = pluginConfig.releaseGitTagVarName || 'releaseGitTag'
+    const releaseNotesVarName = pluginConfig.releaseNotesVarName || 'releaseNotes'
+    const releaseChannelVarName = pluginConfig.releaseChannelVarName || 'releaseChannel'
+
+    if (nextRelease.version) {
+      logger.log(`Setting release version ${nextRelease.version} to the env var ${releaseVersionVarName}`)
+      console.log(`##vso[task.setvariable variable=${releaseVersionVarName};isOutput=${isOutput}]${nextRelease.version}`)
+    }
+
+    if (nextRelease.type) {
+      logger.log(`Setting release type ${nextRelease.type} to the env var ${releaseTypeVarName}`)
+      console.log(`##vso[task.setvariable variable=${releaseTypeVarName};isOutput=${isOutput}]${nextRelease.type}`)
+    }
+
+    if (nextRelease.gitHead) {
+      logger.log(`Setting release gitHead ${nextRelease.gitHead} to the env var ${releaseGitHeadVarName}`)
+      console.log(`##vso[task.setvariable variable=${releaseGitHeadVarName};isOutput=${isOutput}]${nextRelease.gitHead}`)
+    }
+
+    if (nextRelease.gitTag) {
+      logger.log(`Setting release gitTag ${nextRelease.gitTag} to the env var ${releaseGitTagVarName}`)
+      console.log(`##vso[task.setvariable variable=${releaseGitTagVarName};isOutput=${isOutput}]${nextRelease.gitTag}`)
+    }
+
+    if (nextRelease.notes) {
+      logger.log(`Setting release notes to the env var ${releaseNotesVarName}`)
+      console.log(`##vso[task.setvariable variable=${releaseNotesVarName};isOutput=${isOutput}]${nextRelease.notes}`)
+    }
+
+    if (nextRelease.channel) {
+      logger.log(`Setting release channel ${nextRelease.channel} to the env var ${releaseChannelVarName}`)
+      console.log(`##vso[task.setvariable variable=${releaseChannelVarName};isOutput=${isOutput}]${nextRelease.channel}`)
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add support for exposing individual properties from the next release (releaseVersion, releaseType, releaseGitHead, releaseGitTag, releaseChannel) as separate variables in the `verifyRelease` hook
- Add support for exposing individual properties from the last release (lastReleaseVersion, lastReleaseGitHead, lastReleaseGitTag, lastReleaseChannel) as separate variables in the `analyzeCommits` hook
- Add `would_release` boolean variable to indicate whether a release will be published
- Update documentation with configuration examples for the new release object variables

## Changes
- Enhanced `analyzeCommits` to expose last release object properties
- Enhanced `verifyRelease` to expose next release object properties
- Added configurable variable names for all new properties with sensible defaults
- Updated README with comprehensive configuration examples